### PR TITLE
Grid and related products tweaks

### DIFF
--- a/assets/scss/objects/_grid.scss
+++ b/assets/scss/objects/_grid.scss
@@ -16,6 +16,11 @@ $gap-large: map-get($gap-sizes, large);
 
     display: grid;
     gap: $gap-small;
+
+    /* Hide empty children to prevent displaying doubled gaps */
+    & > *:empty {
+        display: none;
+    }
     
 
     @include bp(large) {

--- a/assets/scss/widgets/reviews.scss
+++ b/assets/scss/widgets/reviews.scss
@@ -52,6 +52,7 @@ $swiper-arrow-right-purple: './../icons/arrow-right-purple.svg';
 
     .c-swiper__btn-next,
     .c-swiper__btn-prev {
+        flex-shrink: 0;
         width: rem-calc(24px);
         height: rem-calc(24px);
         border: 0 !important;

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -30,27 +30,31 @@ product:
         {{#all settings.show_product_reviews theme_settings.show_product_reviews (if theme_settings.show_product_details_tabs '!==' true)}}
             {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
         {{/all}}
+    </div>
 
-        {{#if product.related_products}}
-            <h2 class="c-carousel__title">{{lang 'products.related_products'}}</h2>
-            <div>
-                {{#if settings.data_tag_enabled}}
-                    {{> components/products/carousel products=product.related_products columns=6 list="Related Products"}}
-                {{else}}
-                    {{> components/products/carousel products=product.related_products columns=6}}
-                {{/if}}
-            </div>
-        {{/if}}
+    {{#if product.related_products}}
+    <div class="u-margin-top--s">
+        <h2 class="c-carousel__title">{{lang 'products.related_products'}}</h2>
+        <div>
+            {{#if settings.data_tag_enabled}}
+                {{> components/products/carousel products=product.related_products columns=6 list="Related Products"}}
+            {{else}}
+                {{> components/products/carousel products=product.related_products columns=6}}
+            {{/if}}
+        </div>
+    </div>
+    {{/if}}
 
-        {{#if product.similar_by_views}}
+    {{#if product.similar_by_views}}
+        <div class="u-margin-top--s">
             <h2 class="c-carousel__title">{{lang 'products.similar_by_views'}}</h2>
             <div>
                 {{> components/products/carousel products=product.similar_by_views columns=6 list="Customers Also Viewed"}}
             </div>
-        {{/if}}
+        </div>
+    {{/if}}
 
-        {{> components/products/schema}}
-    </div>
+    {{> components/products/schema}}
 
 {{/partial}}
 {{> layout/base}}


### PR DESCRIPTION
- Hide empty child elements within grid to prevent displaying unwanted blank spaces (due to gap)
- Move related products carousel outside the grid due to swiper issue